### PR TITLE
make regiment.id a u32, not u16

### DIFF
--- a/src/army/decoder.rs
+++ b/src/army/decoder.rs
@@ -272,8 +272,7 @@ impl<R: Read + Seek> Decoder<R> {
         Ok(Regiment {
             status,
             unknown1: buf[2..4].try_into().unwrap(),
-            id: u16::from_le_bytes(buf[4..6].try_into().unwrap()),
-            unknown2: buf[6..8].try_into().unwrap(),
+            id: u32::from_le_bytes(buf[4..8].try_into().unwrap()),
             mage_class,
             max_armor: buf[9],
             cost: u16::from_le_bytes(buf[10..12].try_into().unwrap()),

--- a/src/army/encoder.rs
+++ b/src/army/encoder.rs
@@ -94,7 +94,6 @@ impl<W: Write> Encoder<W> {
             .write_all(&Into::<u16>::into(r.status).to_le_bytes())?;
         self.writer.write_all(&r.unknown1)?;
         self.writer.write_all(&r.id.to_le_bytes())?;
-        self.writer.write_all(&r.unknown2)?;
         self.writer.write_all(&[Into::<u8>::into(r.mage_class)])?;
         self.writer.write_all(&[r.max_armor])?;
         self.writer.write_all(&r.cost.to_le_bytes())?;

--- a/src/army/mod.rs
+++ b/src/army/mod.rs
@@ -72,8 +72,7 @@ pub enum ArmyRace {
 pub struct Regiment {
     pub status: RegimentStatus,
     unknown1: [u8; 2],
-    pub id: u16,
-    unknown2: [u8; 2],
+    pub id: u32,
     pub mage_class: MageClass,
     /// The regiment's maximum level of armor.
     pub max_armor: u8,
@@ -696,6 +695,7 @@ mod tests {
         assert_eq!(a.large_banner_path, "[BOOKS]\\hlban.spr");
         assert_eq!(a.regiments.len(), 4);
         assert_eq!(a.regiments[0].status, RegimentStatus::Active);
+        assert_eq!(a.regiments[0].id, 1);
         assert_eq!(a.regiments[0].unit_profile.name, "Grudgebringer Cavalry");
         assert_eq!(
             a.regiments[0].unit_profile.class,
@@ -703,16 +703,19 @@ mod tests {
         );
         assert_eq!(a.regiments[0].unit_profile.mount, RegimentMount::Horse);
         assert_eq!(a.regiments[0].leader_profile.name, "Morgan Bernhardt");
+        assert_eq!(a.regiments[1].id, 2);
         assert_eq!(a.regiments[1].unit_profile.name, "Grudgebringer Infantry");
         assert_eq!(
             a.regiments[1].unit_profile.class,
             RegimentClass::HumanInfantryman
         );
+        assert_eq!(a.regiments[2].id, 3);
         assert_eq!(a.regiments[2].unit_profile.name, "Grudgebringer Crossbows");
         assert_eq!(
             a.regiments[2].unit_profile.class,
             RegimentClass::HumanArcher
         );
+        assert_eq!(a.regiments[3].id, 4);
         assert_eq!(a.regiments[3].unit_profile.name, "Grudgebringer Cannon");
         assert_eq!(
             a.regiments[3].unit_profile.class,


### PR DESCRIPTION
Blueprint `Node.regiment_id` is a u32. Previously `Regiment.id` was a u16 and there were two unknown bytes after it. Those unknown bytes are always 0 and so it's highly likely that `Regiment.id` was meant to be a u32. The way to prove this in game would be to write some non-zero bytes to the unknown slots and see if anything happens.