### PR TITLE
loosen version requirements on dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,16 @@ bevy_reflect = ["dep:bevy_reflect"]
 
 [dependencies]
 bitflags = { version = "2.6", features = ["serde"] }
-encoding_rs = "0.8.34"
-encoding_rs_io = "0.1.7"
+encoding_rs = "0.8"
+encoding_rs_io = "0.1"
 glam = { version = "0.27.0", default-features = false, features = ["serde"] }
-hound = "3.5.1"
-image = "0.25.2"
-indexmap = { version = "2.2.6", features = ["serde"] }
-num_enum = "0.7.3"
-rand = "0.8.5"
+hound = "3.5"
+image = "0.25"
+indexmap = { version = "2.2", features = ["serde"] }
+num_enum = "0.7"
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
-thiserror = "~1.0.61"
+thiserror = "1.0"
 
 [dependencies.bevy_reflect]
 version = "0.14"


### PR DESCRIPTION
This makes it easier for other crates to use this one.