### PR TITLE
rename troop to unit in army code

### DIFF
--- a/src/army/decoder.rs
+++ b/src/army/decoder.rs
@@ -245,15 +245,15 @@ impl<R: Read + Seek> Decoder<R> {
             .ok_or(DecodeError::InvalidRegimentAttributes(attributes_u32))?;
         let mage_class =
             MageClass::try_from(buf[8]).map_err(|_| DecodeError::InvalidMageClass(buf[8]))?;
-        let troop_alignment = RegimentAlignment::try_from(buf[56])
+        let unit_alignment = RegimentAlignment::try_from(buf[56])
             .map_err(|_| DecodeError::InvalidRegimentAlignment(buf[56]))?;
-        let troop_mount = RegimentMount::try_from(buf[73])
+        let unit_mount = RegimentMount::try_from(buf[73])
             .map_err(|_| DecodeError::InvalidRegimentMount(buf[73]))?;
-        let troop_weapon =
+        let unit_weapon =
             Weapon::try_from(buf[75]).map_err(|_| DecodeError::InvalidWeapon(buf[75]))?;
-        let troop_class = RegimentClass::try_from(buf[76])
+        let unit_class = RegimentClass::try_from(buf[76])
             .map_err(|_| DecodeError::InvalidRegimentClass(buf[76]))?;
-        let troop_projectile =
+        let unit_projectile =
             Projectile::try_from(buf[78]).map_err(|_| DecodeError::InvalidProjectile(buf[78]))?;
         let leader_alignment = RegimentAlignment::try_from(buf[120])
             .map_err(|_| DecodeError::InvalidRegimentAlignment(buf[120]))?;
@@ -283,18 +283,18 @@ impl<R: Read + Seek> Decoder<R> {
                 sprite_sheet_index: u16::from_le_bytes(buf[20..22].try_into().unwrap()),
                 name: self.read_string(&buf[22..54])?,
                 name_id: u16::from_le_bytes(buf[54..56].try_into().unwrap()),
-                alignment: troop_alignment,
-                max_troop_count: buf[57],
-                alive_troop_count: buf[58],
+                alignment: unit_alignment,
+                max_unit_count: buf[57],
+                alive_unit_count: buf[58],
                 rank_count: buf[59],
                 unknown1: buf[60..64].into(),
                 stats: self.read_unit_stats(&buf[64..73]),
-                mount: troop_mount,
+                mount: unit_mount,
                 armor: buf[74],
-                weapon: troop_weapon,
-                class: troop_class,
+                weapon: unit_weapon,
+                class: unit_class,
                 point_value: buf[77],
-                projectile: troop_projectile,
+                projectile: unit_projectile,
             },
             unknown4: buf[79],
             unknown5: buf[80..84].try_into().unwrap(),
@@ -303,8 +303,8 @@ impl<R: Read + Seek> Decoder<R> {
                 name: self.read_string(&buf[86..118])?,
                 name_id: u16::from_le_bytes(buf[118..120].try_into().unwrap()),
                 alignment: leader_alignment,
-                max_troop_count: buf[121],
-                alive_troop_count: buf[122],
+                max_unit_count: buf[121],
+                alive_unit_count: buf[122],
                 rank_count: buf[123],
                 unknown1: buf[124..127].into(),
                 stats: self.read_unit_stats(&buf[127..136]),
@@ -330,8 +330,8 @@ impl<R: Read + Seek> Decoder<R> {
             unknown8: buf[168..180].try_into().unwrap(),
             purchased_armor: buf[180],
             max_purchasable_armor: buf[181],
-            repurchased_troop_count: buf[182],
-            max_purchasable_troop_count: buf[183],
+            repurchased_unit_count: buf[182],
+            max_purchasable_unit_count: buf[183],
             book_profile: buf[184..188].try_into().unwrap(),
         })
     }

--- a/src/army/encoder.rs
+++ b/src/army/encoder.rs
@@ -119,8 +119,8 @@ impl<W: Write> Encoder<W> {
         self.writer.write_all(&r.unknown8)?;
         self.writer.write_all(&[r.purchased_armor])?;
         self.writer.write_all(&[r.max_purchasable_armor])?;
-        self.writer.write_all(&[r.repurchased_troop_count])?;
-        self.writer.write_all(&[r.max_purchasable_troop_count])?;
+        self.writer.write_all(&[r.repurchased_unit_count])?;
+        self.writer.write_all(&[r.max_purchasable_unit_count])?;
         self.writer.write_all(&r.book_profile)?;
 
         Ok(())
@@ -131,8 +131,8 @@ impl<W: Write> Encoder<W> {
         self.write_string_with_limit(&u.name, 32)?;
         self.writer.write_all(&u.name_id.to_le_bytes())?;
         self.writer.write_all(&[Into::<u8>::into(u.alignment)])?;
-        self.writer.write_all(&[u.max_troop_count])?;
-        self.writer.write_all(&[u.alive_troop_count])?;
+        self.writer.write_all(&[u.max_unit_count])?;
+        self.writer.write_all(&[u.alive_unit_count])?;
         self.writer.write_all(&[u.rank_count])?;
         self.writer.write_all(&u.unknown1)?;
         self.writer.write_all(&[u.stats.movement])?;

--- a/src/army/mod.rs
+++ b/src/army/mod.rs
@@ -129,8 +129,8 @@ pub struct Regiment {
     unknown8: [u8; 12],
     pub purchased_armor: u8,
     pub max_purchasable_armor: u8,
-    pub repurchased_troop_count: u8,
-    pub max_purchasable_troop_count: u8,
+    pub repurchased_unit_count: u8,
+    pub max_purchasable_unit_count: u8,
     pub book_profile: [u8; 4],
 }
 
@@ -144,7 +144,7 @@ impl Regiment {
     /// Returns the number of units in the regiment that are alive.
     #[inline]
     pub fn alive_unit_count(&self) -> usize {
-        self.unit_profile.alive_troop_count as usize
+        self.unit_profile.alive_unit_count as usize
     }
 
     /// Returns the rank count.
@@ -479,10 +479,10 @@ pub struct UnitProfile {
     /// - 0x40 (decimal 64) is neutral.
     /// - 0x80 (decimal 128) is evil.
     pub alignment: RegimentAlignment,
-    /// The maximum number of troops allowed in the regiment.
-    pub max_troop_count: u8,
-    /// The number of troops currently alive in the regiment.
-    pub alive_troop_count: u8,
+    /// The maximum number of units allowed in the regiment.
+    pub max_unit_count: u8,
+    /// The number of units currently alive in the regiment.
+    pub alive_unit_count: u8,
     pub rank_count: u8,
     unknown1: Vec<u8>,
     pub stats: UnitStats,


### PR DESCRIPTION
The terminology we're using is regiment, unit and leader (which is also a unit).