### PR TITLE
enable `cli` feature by default

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo publish --features=cli
+      - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 exclude = ["testdata/"]
 
 [features]
-default = []
+default = ["cli"]
 bevy_reflect = ["dep:bevy_reflect"]
 cli = ["dep:anyhow", "dep:clap", "dep:ron", "dep:tempfile"]
 
@@ -49,8 +49,8 @@ version = "3"
 optional = true
 
 [dev-dependencies]
-# Enable the `bevy_reflect` and `cli` features when testing.
-darkomen = { path = ".", features = ["bevy_reflect", "cli"] }
+# Enable the `bevy_reflect` feature when testing.
+darkomen = { path = ".", features = ["bevy_reflect"] }
 imageproc = "0.25"
 pretty_assertions = "1.4"
 rand_chacha = "0.3"


### PR DESCRIPTION
So that when installing using `cargo install darkomen`, users don't need to pass the `cli` feature.