### PR TITLE
revert the reflect bitflags changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Warhammer: Dark Omen library in Rust
+# Warhammer: Dark Omen library and CLI in Rust
 
 [![Crates.io](https://img.shields.io/crates/v/darkomen.svg)](https://crates.io/crates/darkomen)
 [![Docs.rs](https://docs.rs/darkomen/badge.svg)](https://docs.rs/darkomen)

--- a/src/army/mod.rs
+++ b/src/army/mod.rs
@@ -382,13 +382,12 @@ pub enum RegimentMount {
     Boar,
 }
 
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
-pub struct RegimentAttributes(u32);
-
 bitflags! {
-    impl RegimentAttributes: u32 {
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+    #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+    #[cfg_attr(feature = "bevy_reflect", reflect_value(Debug, Default, Deserialize, Hash, PartialEq, Serialize))]
+    pub struct RegimentAttributes: u32 {
         const NONE = 0;
         /// The regiment never retreats from a fight and the retreat button is
         /// disabled.

--- a/src/battle/mod.rs
+++ b/src/battle/mod.rs
@@ -70,13 +70,12 @@ impl Obstacle {
     }
 }
 
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
-pub struct ObstacleFlags(u32);
-
 bitflags! {
-    impl ObstacleFlags: u32 {
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+    #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+    #[cfg_attr(feature = "bevy_reflect", reflect_value(Debug, Default, Deserialize, Hash, PartialEq, Serialize))]
+    pub struct ObstacleFlags: u32 {
         const NONE = 0;
         const IS_ENABLED = 1 << 0;
         const BLOCKS_MOVEMENT = 1 << 1;
@@ -199,19 +198,20 @@ impl Region {
     }
 }
 
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
-pub struct RegionFlags(u32);
-
 bitflags! {
-    impl RegionFlags: u32 {
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+    #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+    #[cfg_attr(feature = "bevy_reflect", reflect_value(Debug, Default, Deserialize, Hash, PartialEq, Serialize))]
+    pub struct RegionFlags: u32 {
         const NONE = 0;
         const UNKNOWN_FLAG_1 = 1 << 0;
         const IS_CLOSED = 1 << 1;
         const IS_OPEN = 1 << 2;
         const UNKNOWN_FLAG_2 = 1 << 3;
+        /// The region is used for holes in the battle's navmesh.
         const IS_BOUNDARY_REVERSED = 1 << 4;
+        /// The region is used for the outer geometry of the battle's navmesh.
         const IS_BATTLE_BOUNDARY = 1 << 5;
         const UNKNOWN_FLAG_3 = 1 << 6;
         const IS_BOUNDARY = 1 << 7;
@@ -298,13 +298,12 @@ impl Node {
     }
 }
 
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
-pub struct NodeFlags(u32);
-
 bitflags! {
-    impl NodeFlags: u32 {
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+    #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+    #[cfg_attr(feature = "bevy_reflect", reflect_value(Debug, Default, Deserialize, Hash, PartialEq, Serialize))]
+    pub struct NodeFlags: u32 {
         const NONE = 0;
         const IS_CENTERED_POINT = 1 << 0;
         const IS_REGIMENT = 1 << 1;

--- a/src/m3d/mod.rs
+++ b/src/m3d/mod.rs
@@ -41,13 +41,12 @@ impl TextureDescriptor {
     }
 }
 
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
-pub struct ObjectFlags(u32);
-
 bitflags! {
-    impl ObjectFlags: u32 {
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+    #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+    #[cfg_attr(feature = "bevy_reflect", reflect_value(Debug, Default, Deserialize, Hash, PartialEq, Serialize))]
+    pub struct ObjectFlags: u32 {
         const NONE = 0;
         const UNKNOWN_FLAG_1 = 1 << 0;
         const CUSTOM_TRANSLATION_ENABLED = 1 << 1;

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -362,13 +362,12 @@ pub struct TrackControlPoint {
     pub flags: TrackControlPointFlags,
 }
 
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
-pub struct TrackControlPointFlags(u32);
-
 bitflags! {
-    impl TrackControlPointFlags: u32 {
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+    #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+    #[cfg_attr(feature = "bevy_reflect", reflect_value(Debug, Default, Deserialize, Hash, PartialEq, Serialize))]
+    pub struct TrackControlPointFlags: u32 {
         const NONE = 0;
         const UNKNOWN_FLAG_1 = 1 << 0;
         const UNKNOWN_FLAG_2 = 1 << 1;

--- a/src/sound/sfx/mod.rs
+++ b/src/sound/sfx/mod.rs
@@ -96,13 +96,12 @@ impl TryFrom<u8> for SfxType {
     }
 }
 
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
-pub struct SfxFlags(u8);
-
 bitflags! {
-    impl SfxFlags: u8 {
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+    #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+    #[cfg_attr(feature = "bevy_reflect", reflect_value(Debug, Default, Deserialize, Hash, PartialEq, Serialize))]
+    pub struct SfxFlags: u8 {
         const NONE = 0;
         const UNKNOWN_FLAG_1 = 1 << 0;
         const UNKNOWN_FLAG_2 = 1 << 1;


### PR DESCRIPTION
#24 makes bevy-inspector-egui a little more useful because the bitflag becomes an int in the UI. But RON/JSON decoding is less useful because you no longer get the nice formatting like `A | B | C`. That's useful for the CLI when editing RON/JSON files and it's also useful to visually see what flags something has in RON/JSON rather than just an int.