### PR TITLE
tidy naming of functions that return booleans

### DIFF
--- a/src/battle/mod.rs
+++ b/src/battle/mod.rs
@@ -118,8 +118,8 @@ impl LineSegment {
         Vec2::new(self.end.x as f32 / SCALE, self.end.y as f32 / SCALE)
     }
 
-    /// Checks if a point is on a line segment.
-    fn point_on_line_segment(&self, point: &IVec2) -> bool {
+    /// Returns `true` if a point is on a line segment.
+    fn is_point_on_line_segment(&self, point: &IVec2) -> bool {
         let crossproduct = (point.y - self.start.y) * (self.end.x - self.start.x)
             - (point.x - self.start.x) * (self.end.y - self.start.y);
         if crossproduct != 0 {
@@ -141,8 +141,9 @@ impl LineSegment {
         true
     }
 
-    /// Checks if the ray from the point intersects with the line segment.
-    fn ray_intersects_segment(&self, point: &IVec2) -> bool {
+    /// Returns `true` if the ray from the point is intersecting with the line
+    /// segment.
+    fn is_ray_intersecting_segment(&self, point: &IVec2) -> bool {
         // Ensure the point is between the y-coordinates of the line segment's
         // endpoints.
         if point.y < self.start.y.min(self.end.y) || point.y > self.start.y.max(self.end.y) {
@@ -172,23 +173,23 @@ pub struct Region {
 }
 
 impl Region {
-    /// Returns whether the region is a deployment zone.
+    /// Returns `true` if the region is a deployment zone.
     pub fn is_deployment_zone(&self) -> bool {
         self.flags.contains(RegionFlags::IS_PLAYER1_DEPLOYMENT_ZONE)
             || self.flags.contains(RegionFlags::IS_PLAYER2_DEPLOYMENT_ZONE)
     }
 
-    /// Returns whether the given point is contained within the region.
-    pub fn contains_point(&self, point: IVec2) -> bool {
+    /// Returns `true` if the given point is contained within the region.
+    pub fn is_point_contained(&self, point: IVec2) -> bool {
         let mut intersections = 0;
         for line in &self.line_segments {
             // Check if point is exactly on the line segment.
-            if line.point_on_line_segment(&point) {
+            if line.is_point_on_line_segment(&point) {
                 return true;
             }
 
             // Check for intersections with the ray.
-            if line.ray_intersects_segment(&point) {
+            if line.is_ray_intersecting_segment(&point) {
                 intersections += 1;
             }
         }
@@ -253,7 +254,7 @@ pub struct Node {
 }
 
 impl Node {
-    /// Returns whether the node is a waypoint.
+    /// Returns `true` if the node is a waypoint.
     #[inline]
     pub fn is_waypoint(&self) -> bool {
         self.flags.contains(NodeFlags::IS_WAYPOINT)
@@ -289,7 +290,7 @@ impl Node {
         self.rotation_radians().to_degrees()
     }
 
-    /// Returns whether the node belongs to player 1's regiment.
+    /// Returns `true` if the node belongs to player 1's regiment.
     ///
     /// TODO: Is there a more reliable way to determine this?
     #[inline]
@@ -329,7 +330,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_region_contains_point() {
+    fn test_region_is_point_contained() {
         let region = Region {
             line_segments: vec![
                 LineSegment {
@@ -352,14 +353,14 @@ mod tests {
             ..Default::default()
         };
 
-        assert!(region.contains_point(IVec2::new(5, 5)));
-        assert!(region.contains_point(IVec2::new(0, 0)));
-        assert!(region.contains_point(IVec2::new(10, 0)));
-        assert!(region.contains_point(IVec2::new(10, 10)));
-        assert!(region.contains_point(IVec2::new(0, 10)));
-        assert!(!region.contains_point(IVec2::new(11, 0)));
-        assert!(!region.contains_point(IVec2::new(0, 11)));
-        assert!(!region.contains_point(IVec2::new(11, 11)));
+        assert!(region.is_point_contained(IVec2::new(5, 5)));
+        assert!(region.is_point_contained(IVec2::new(0, 0)));
+        assert!(region.is_point_contained(IVec2::new(10, 0)));
+        assert!(region.is_point_contained(IVec2::new(10, 10)));
+        assert!(region.is_point_contained(IVec2::new(0, 10)));
+        assert!(!region.is_point_contained(IVec2::new(11, 0)));
+        assert!(!region.is_point_contained(IVec2::new(0, 11)));
+        assert!(!region.is_point_contained(IVec2::new(11, 11)));
     }
 
     #[test]

--- a/src/m3d/mod.rs
+++ b/src/m3d/mod.rs
@@ -27,15 +27,15 @@ pub struct TextureDescriptor {
     pub file_name: String,
 }
 
+/// Texture flags embedded in the prefix of the file name, e.g. `_1WOOD8.bmp`,
+/// `_2wtpool.bmp`. The prefix is either: `_1`, `_2`, or no prefix.
+///
+/// - `_1` seems like it's possibly just color keying
+/// - `_2` are all water (and jewel) textures, so must possibly to do with
+///   transparency, translucency or animation.
 impl TextureDescriptor {
-    /// Texture flags embedded in the prefix of the file name, e.g.
-    /// `_1WOOD8.bmp`, `_2wtpool.bmp`. The prefix is either: `_1`, `_2`, or no
-    /// prefix.
-    ///
-    /// - `_1` seems like it's possibly just color keying
-    /// - `_2` are all water (and jewel) textures, so must possibly to do with
-    ///   transparency, translucency or animation.
-
+    /// Returns `true` if the texture descriptor indicates that the texture is
+    /// color keyed.
     pub fn is_color_keyed(&self) -> bool {
         self.file_name.to_ascii_lowercase().starts_with("_1")
     }

--- a/src/sound/script/mod.rs
+++ b/src/sound/script/mod.rs
@@ -112,11 +112,13 @@ impl<'a> IntoIterator for &'a Sequence {
 }
 
 impl Sequence {
+    /// Returns the number of samples in the sequence.
     #[inline]
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// Returns `true` if the sequence is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0


### PR DESCRIPTION
See [std lib] bool functions.

[std lib]: https://doc.rust-lang.org/stable/std/?search=-%3E%20bool