### PR TITLE
add TextureDescriptor.anchor for sprite sheet

### DIFF
--- a/src/graphics/sprite_sheet/mod.rs
+++ b/src/graphics/sprite_sheet/mod.rs
@@ -4,6 +4,7 @@ mod zeroruns;
 
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
+use glam::Vec2;
 use image::DynamicImage;
 use serde::Serialize;
 
@@ -27,4 +28,13 @@ pub struct TextureDescriptor {
     pub y: i16,
     pub width: u16,
     pub height: u16,
+}
+
+impl TextureDescriptor {
+    pub fn anchor(&self) -> Vec2 {
+        Vec2::new(
+            (self.x.abs() as f32 - (self.width as f32 / 2.0)) / self.width as f32,
+            (self.y.abs() as f32 - (self.height as f32 / 2.0)) / self.height as f32,
+        )
+    }
 }


### PR DESCRIPTION
It seems to work at least for the 3D in world magic items. Not sure if it works for every sprite sheet though. It's a start at least.