### PR TITLE
rename project music field to just music_script

### DIFF
--- a/src/army/mod.rs
+++ b/src/army/mod.rs
@@ -48,7 +48,7 @@ impl ScriptState {
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub struct SaveGameHeader {
-    /// The name displayed when loading the save file.
+    /// The name displayed when loading the save game.
     pub display_name: String,
     /// The original game writes over the existing display name with the new
     /// path but the old bytes are not cleared first. This field is used to

--- a/src/project/decoder.rs
+++ b/src/project/decoder.rs
@@ -106,7 +106,7 @@ impl<R: Read + Seek> Decoder<R> {
         let terrain = self.read_terrain()?;
         let attributes = self.read_attributes()?;
         let excl = self.read_excl()?;
-        let background_music_script_file_name = self.read_music()?;
+        let music_script_file_name = self.read_music()?;
         let tracks = self.read_tracks()?;
         let edit = self.read_edit()?;
 
@@ -118,7 +118,7 @@ impl<R: Read + Seek> Decoder<R> {
             terrain,
             attributes,
             excl,
-            background_music_script_file_name,
+            music_script_file_name,
             tracks,
             edit,
         })

--- a/src/project/encoder.rs
+++ b/src/project/encoder.rs
@@ -261,7 +261,7 @@ impl<W: Write> Encoder<W> {
     fn write_music(&mut self, p: &Project) -> Result<(), EncodeError> {
         self.write_string(MUSIC_BLOCK_ID)?;
 
-        let c_string = self.make_c_string(&p.background_music_script_file_name)?;
+        let c_string = self.make_c_string(&p.music_script_file_name)?;
         self.write_c_string_with_limit(&c_string, MUSIC_BLOCK_DATA_SIZE_BYTES)?;
 
         Ok(())

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -39,9 +39,10 @@ pub struct Project {
     pub attributes: Attributes,
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore))]
     excl: Excl,
-    /// The background music script file name, including the extension. E.g.
-    /// `battle1.fsm`.
-    pub background_music_script_file_name: String,
+    /// The music script file name, including the extension. E.g. `battle1.fsm`.
+    /// This can be used to play background music during a battle, or on various
+    /// UI screens.
+    pub music_script_file_name: String,
     pub tracks: Vec<Track>,
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore))]
     edit: Vec<u8>,
@@ -469,7 +470,7 @@ mod tests {
         assert_eq!(p.terrain.height_in_blocks(), 25);
         assert_eq!(p.attributes.width, 184);
         assert_eq!(p.attributes.height, 200);
-        assert_eq!(p.background_music_script_file_name, "battle1.fsm");
+        assert_eq!(p.music_script_file_name, "battle1.fsm");
         assert_eq!(p.tracks.len(), 2);
         assert_eq!(p.tracks[0].control_points.len(), 6);
         assert_eq!(p.tracks[0].points.len(), 135);


### PR DESCRIPTION
`background_` prefix is overkill. "Music" alone as a term for the music playing in the background seems obvious enough. Keeping the `_script` suffix since it's not just a single music audio file name, but rather a music script file name.