### PR TITLE
fix project instance position is encoded as i32s not u32s

### DIFF
--- a/src/project/decoder.rs
+++ b/src/project/decoder.rs
@@ -243,7 +243,7 @@ impl<R: Read + Seek> Decoder<R> {
             next: i32::from_le_bytes(buf[4..8].try_into().unwrap()),
             selected: i32::from_le_bytes(buf[8..12].try_into().unwrap()),
             exclude_from_terrain: i32::from_le_bytes(buf[12..16].try_into().unwrap()),
-            position: self.read_dvec3_from_u32s(&buf[16..28], 1024.)?,
+            position: self.read_dvec3_from_i32s(&buf[16..28], 1024.)?,
             rotation: self.read_dvec3_from_u32s(&buf[28..40], 4096.)?,
             aabb_min: self.read_dvec3_from_i32s(&buf[40..52], 1024.)?,
             aabb_max: self.read_dvec3_from_i32s(&buf[52..64], 1024.)?,

--- a/src/project/encoder.rs
+++ b/src/project/encoder.rs
@@ -154,7 +154,7 @@ impl<W: Write> Encoder<W> {
         self.writer.write_all(&i.selected.to_le_bytes())?;
         self.writer
             .write_all(&i.exclude_from_terrain.to_le_bytes())?;
-        self.write_dvec3_from_u32s(&i.position, 1024.0)?;
+        self.write_dvec3_from_i32s(&i.position, 1024.0)?;
         self.write_dvec3_from_u32s(&i.rotation, 4096.0)?;
         self.write_dvec3_from_i32s(&i.aabb_min, 1024.0)?;
         self.write_dvec3_from_i32s(&i.aabb_max, 1024.0)?;

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -506,6 +506,32 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_b2_01() {
+        let d: PathBuf = [
+            std::env::var("DARKOMEN_PATH").unwrap().as_str(),
+            "DARKOMEN",
+            "GAMEDATA",
+            "1PBAT",
+            "B2_01",
+            "B2_01.PRJ",
+        ]
+        .iter()
+        .collect();
+
+        let original_bytes = std::fs::read(d.clone()).unwrap();
+
+        let file = File::open(d.clone()).unwrap();
+        let p = Decoder::new(file).decode().unwrap();
+
+        assert_eq!(
+            p.instances[0].position,
+            DVec3::new(60.953125, -1.9990234375, 57.859375)
+        );
+
+        roundtrip_test(&original_bytes, &p);
+    }
+
+    #[test]
     fn test_decode_mb4_01() {
         let d: PathBuf = [
             std::env::var("DARKOMEN_PATH").unwrap().as_str(),


### PR DESCRIPTION
Noticed some really large `y` values which hinted at an overflow. Negative `y` is valid, so this should always have been i32 not u32.