### PR TITLE
Revert "cargo: bump ron from 0.8.1 to 0.9.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,12 +358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "bevy"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,7 +439,7 @@ dependencies = [
  "futures-lite",
  "js-sys",
  "parking_lot",
- "ron 0.8.1",
+ "ron",
  "serde",
  "stackfuture",
  "uuid",
@@ -1604,7 +1598,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "regex",
- "ron 0.10.1",
+ "ron",
  "serde",
  "serde_json",
  "sha2",
@@ -3294,23 +3288,10 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "bitflags 2.9.0",
  "serde",
  "serde_derive",
-]
-
-[[package]]
-name = "ron"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beceb6f7bf81c73e73aeef6dd1356d9a1b2b4909e1f0fc3e59b034f9572d7b7f"
-dependencies = [
- "base64 0.22.1",
- "bitflags 2.9.0",
- "serde",
- "serde_derive",
- "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ image = "0.25"
 indexmap = { version = "2.9", features = ["serde"] }
 num_enum = "0.7"
 rand = "0.8"
-ron = { version = "0.10", optional = true }
+ron = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 tempfile = { version = "3.16", optional = true }
@@ -132,7 +132,7 @@ imageproc = "0.25"
 pretty_assertions = "1.4"
 rand_chacha = "0.3"
 regex = "1.11"
-ron = "0.10"
+ron = "0.8"
 sha2 = "0.10"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Reverts mgi388/darkomen#314

`bevy_asset` depends on `ron = "0.8"` it seems.