### PR TITLE
rename to army 1 and army 2

### DIFF
--- a/src/asset/battle_tabletop.rs
+++ b/src/asset/battle_tabletop.rs
@@ -30,8 +30,8 @@ impl Plugin for BattleTabletopAssetPlugin {
 pub struct BattleTabletopAsset {
     source: BattleTabletop,
 
-    pub player_army: Option<Handle<ArmyAsset>>,
-    pub enemy_army: Option<Handle<ArmyAsset>>,
+    pub army1: Option<Handle<ArmyAsset>>,
+    pub army2: Option<Handle<ArmyAsset>>,
 }
 
 impl BattleTabletopAsset {
@@ -70,10 +70,10 @@ pub struct BattleTabletopAssetLoader;
 #[reflect(Default, Deserialize, Serialize)]
 #[cfg_attr(all(feature = "bevy_reflect", feature = "debug"), reflect(Debug))]
 pub struct BattleTabletopAssetLoaderSettings {
-    pub load_player_army: bool,
-    pub player_army_loader_settings: Option<ArmyAssetLoaderSettings>,
-    pub load_enemy_army: bool,
-    pub enemy_army_loader_settings: Option<ArmyAssetLoaderSettings>,
+    pub load_army1: bool,
+    pub army1_loader_settings: Option<ArmyAssetLoaderSettings>,
+    pub load_army2: bool,
+    pub army2_loader_settings: Option<ArmyAssetLoaderSettings>,
 }
 
 /// Possible errors that can be produced by [BattleTabletopAssetLoader].
@@ -114,27 +114,27 @@ impl AssetLoader for BattleTabletopAssetLoader {
 
         Ok(BattleTabletopAsset {
             source: btb.clone(),
-            player_army: if settings.load_player_army {
+            army1: if settings.load_army1 {
                 let mut b = load_context.loader();
-                if let Some(ref s) = settings.player_army_loader_settings {
+                if let Some(ref s) = settings.army1_loader_settings {
                     let s = *s;
                     b = b.with_settings(move |settings| {
                         *settings = s;
                     });
                 }
-                Some(b.load(parent_path.join(btb.player_army).with_extension("ARM")))
+                Some(b.load(parent_path.join(btb.army1_file_stem).with_extension("ARM")))
             } else {
                 None
             },
-            enemy_army: if settings.load_enemy_army {
+            army2: if settings.load_army2 {
                 let mut b = load_context.loader();
-                if let Some(ref s) = settings.enemy_army_loader_settings {
+                if let Some(ref s) = settings.army2_loader_settings {
                     let s = *s;
                     b = b.with_settings(move |settings| {
                         *settings = s;
                     });
                 }
-                Some(b.load(parent_path.join(btb.enemy_army).with_extension("ARM")))
+                Some(b.load(parent_path.join(btb.army2_file_stem).with_extension("ARM")))
             } else {
                 None
             },

--- a/src/battle_tabletop/decoder.rs
+++ b/src/battle_tabletop/decoder.rs
@@ -75,8 +75,16 @@ impl<R: Read + Seek> Decoder<R> {
 
     pub fn decode(&mut self) -> Result<BattleTabletop, DecodeError> {
         self.read_btb_file_type()?;
-        let (width, height, player_army, enemy_army, ctl, unknown1, unknown2, unknown3) =
-            self.read_battle_header()?;
+        let (
+            width,
+            height,
+            army1_file_stem,
+            army2_file_stem,
+            ctl_file_stem,
+            unknown1,
+            unknown2,
+            unknown3,
+        ) = self.read_battle_header()?;
         let objectives = self.read_objectives()?;
         let (obstacles, obstacles_unknown1) = self.read_obstacles()?;
         let regions = self.read_regions()?;
@@ -86,9 +94,9 @@ impl<R: Read + Seek> Decoder<R> {
         Ok(BattleTabletop {
             width,
             height,
-            player_army,
-            enemy_army,
-            ctl,
+            army1_file_stem,
+            army2_file_stem,
+            ctl_file_stem,
             unknown1,
             unknown2,
             unknown3,
@@ -113,9 +121,9 @@ impl<R: Read + Seek> Decoder<R> {
 
         let width = self.read_int_tuple_property::<i32>(1, 1)?[0] as u32;
         let height = self.read_int_tuple_property::<i32>(2, 1)?[0] as u32;
-        let (player_army, _) = self.read_string_property(1001)?;
-        let (enemy_army, _) = self.read_string_property(1002)?;
-        let (ctl, _) = self.read_string_property(1003)?;
+        let (army1_file_stem, _) = self.read_string_property(1001)?;
+        let (army2_file_stem, _) = self.read_string_property(1002)?;
+        let (ctl_file_stem, _) = self.read_string_property(1003)?;
         let (unknown1, _) = self.read_string_property(1004)?;
         let (unknown2, _) = self.read_string_property(1005)?;
         let unknown3 = self.read_int_tuple_property::<i32>(9, 2)?;
@@ -123,9 +131,9 @@ impl<R: Read + Seek> Decoder<R> {
         Ok((
             width,
             height,
-            player_army,
-            enemy_army,
-            ctl,
+            army1_file_stem,
+            army2_file_stem,
+            ctl_file_stem,
             unknown1,
             unknown2,
             unknown3,

--- a/src/battle_tabletop/encoder.rs
+++ b/src/battle_tabletop/encoder.rs
@@ -87,9 +87,9 @@ impl<W: Write> Encoder<W> {
 
         self.write_int_tuple_property(1, &[bt.width as i32])?;
         self.write_int_tuple_property(2, &[bt.height as i32])?;
-        self.write_string_property(1001, &bt.player_army, None)?;
-        self.write_string_property(1002, &bt.enemy_army, None)?;
-        self.write_string_property(1003, &bt.ctl, None)?;
+        self.write_string_property(1001, &bt.army1_file_stem, None)?;
+        self.write_string_property(1002, &bt.army2_file_stem, None)?;
+        self.write_string_property(1003, &bt.ctl_file_stem, None)?;
         self.write_string_property(1004, &bt.unknown1, None)?;
         self.write_string_property(1005, &bt.unknown2, None)?;
         self.write_int_tuple_property(9, &bt.unknown3)?;

--- a/src/battle_tabletop/mod.rs
+++ b/src/battle_tabletop/mod.rs
@@ -27,14 +27,18 @@ pub const SCALE: f32 = 8.;
 pub struct BattleTabletop {
     pub width: u32,
     pub height: u32,
-    /// The name of the player's army file, without the extension, e.g.,
-    /// `b101mrc`.
-    pub player_army: String,
-    /// The name of the enemy's army file, without the extension, e.g.,
-    /// `b101nme`.
-    pub enemy_army: String,
+    /// The name of the army 1 file, without the extension, e.g., `b101mrc`.
+    ///
+    /// This is used for the player army in singleplayer and player 1's army in
+    /// multiplayer.
+    pub army1_file_stem: String,
+    /// The name of the army 2 file, without the extension, e.g., `b101nme`.
+    ///
+    /// This is used for the enemy army in singleplayer player 2's army in
+    /// multiplayer.
+    pub army2_file_stem: String,
     /// The name of the CTL file, without the extension, e.g., `B101`.
-    pub ctl: String,
+    pub ctl_file_stem: String,
     unknown1: String,
     unknown2: String,
     unknown3: Vec<i32>,
@@ -246,18 +250,18 @@ pub struct Region {
 impl Region {
     /// Returns `true` if the region is a deployment zone.
     pub fn is_deployment_zone(&self) -> bool {
-        self.flags.contains(RegionFlags::PLAYER1_DEPLOYMENT_ZONE)
-            || self.flags.contains(RegionFlags::PLAYER2_DEPLOYMENT_ZONE)
+        self.flags.contains(RegionFlags::ARMY1_DEPLOYMENT_ZONE)
+            || self.flags.contains(RegionFlags::ARMY2_DEPLOYMENT_ZONE)
     }
 
-    /// Returns `true` if the region is a player 1 deployment zone.
-    pub fn is_player1_deployment_zone(&self) -> bool {
-        self.flags.contains(RegionFlags::PLAYER1_DEPLOYMENT_ZONE)
+    /// Returns `true` if the region is an army 1 deployment zone.
+    pub fn is_army1_deployment_zone(&self) -> bool {
+        self.flags.contains(RegionFlags::ARMY1_DEPLOYMENT_ZONE)
     }
 
-    /// Returns `true` if the region is a player 2 deployment zone.
-    pub fn is_player2_deployment_zone(&self) -> bool {
-        self.flags.contains(RegionFlags::PLAYER2_DEPLOYMENT_ZONE)
+    /// Returns `true` if the region is an army 2 deployment zone.
+    pub fn is_army2_deployment_zone(&self) -> bool {
+        self.flags.contains(RegionFlags::ARMY2_DEPLOYMENT_ZONE)
     }
 
     /// Returns `true` if the given point is contained within the region.
@@ -308,10 +312,13 @@ bitflags! {
         const BATTLE_BOUNDARY = 1 << 5;
         const UNKNOWN_FLAG_3 = 1 << 6;
         const BOUNDARY = 1 << 7;
-        /// The region is a deployment zone for player 1, i.e., the main player.
-        const PLAYER1_DEPLOYMENT_ZONE = 1 << 8;
-        /// The region is a deployment zone for player 2, i.e., the enemy.
-        const PLAYER2_DEPLOYMENT_ZONE = 1 << 9;
+        /// The region is a deployment zone for army 1. This is the player
+        /// deployment zone in singleplayer and player 1's deployment zone in
+        /// multiplayer.
+        const ARMY1_DEPLOYMENT_ZONE = 1 << 8;
+        /// The region is a deployment zone for army 2. This is player 2's
+        /// deployment zone in multiplayer.
+        const ARMY2_DEPLOYMENT_ZONE = 1 << 9;
         const VISIBLE_AREA = 1 << 10;
         const UNKNOWN_FLAG_4 = 1 << 11;
         const UNKNOWN_FLAG_5 = 1 << 12;
@@ -386,14 +393,6 @@ impl Node {
     #[inline]
     pub fn rotation_degrees(&self) -> f32 {
         self.rotation_radians().to_degrees()
-    }
-
-    /// Returns `true` if the node belongs to player 1's regiment.
-    ///
-    /// TODO: Is there a more reliable way to determine this?
-    #[inline]
-    pub fn is_player1_regiment(&self) -> bool {
-        self.regiment_id <= 100
     }
 }
 
@@ -555,9 +554,9 @@ mod tests {
 
         assert_eq!(b.width, 1440);
         assert_eq!(b.height, 1600);
-        assert_eq!(b.player_army, "B101mrc");
-        assert_eq!(b.enemy_army, "B101nme");
-        assert_eq!(b.ctl, "B101");
+        assert_eq!(b.army1_file_stem, "B101mrc");
+        assert_eq!(b.army2_file_stem, "B101nme");
+        assert_eq!(b.ctl_file_stem, "B101");
 
         const EPSILON: f32 = 0.0001;
 


### PR DESCRIPTION
"Army 1" is used for the player army in singleplayer and player 1's army in multiplayer.

"Army 2" is used for the enemy army in singleplayer player 2's army in multiplayer.

Therefore, "player" and "enemy" didn't really make sense.